### PR TITLE
Allow to upload, dump, validate only jobs which are assigned to the user

### DIFF
--- a/cvat-core/src/annotations.js
+++ b/cvat-core/src/annotations.js
@@ -217,17 +217,17 @@
         );
     }
 
-    async function uploadAnnotations(session, file, loader) {
+    async function uploadAnnotations(session, file, loader, jobs) {
         const sessionType = session instanceof Task ? 'task' : 'job';
         if (!(loader instanceof Loader)) {
             throw new ArgumentError(
                 'A loader must be instance of Loader class',
             );
         }
-        await serverProxy.annotations.uploadAnnotations(sessionType, session.id, file, loader.name);
+        await serverProxy.annotations.uploadAnnotations(sessionType, session.id, file, loader.name, jobs);
     }
 
-    async function dumpAnnotations(session, name, dumper) {
+    async function dumpAnnotations(session, name, dumper, jobs) {
         if (!(dumper instanceof Dumper)) {
             throw new ArgumentError(
                 'A dumper must be instance of Dumper class',
@@ -238,10 +238,10 @@
         const sessionType = session instanceof Task ? 'task' : 'job';
         if (sessionType === 'job') {
             result = await serverProxy.annotations
-                .dumpAnnotations(session.task.id, name, dumper.name);
+                .dumpAnnotations(session.task.id, name, dumper.name, jobs);
         } else {
             result = await serverProxy.annotations
-                .dumpAnnotations(session.id, name, dumper.name);
+                .dumpAnnotations(session.id, name, dumper.name, jobs);
         }
 
         return result;

--- a/cvat-core/src/server-proxy.js
+++ b/cvat-core/src/server-proxy.js
@@ -253,7 +253,7 @@
                 const { backendAPI } = config;
 
                 let query = "";
-                if (jobs !== null) {
+                if (jobs) {
                     const queryParams = new URLSearchParams();
                     queryParams.append("jobs", jobs);
                     query = `?${queryParams}`;
@@ -563,7 +563,7 @@
                     async function request() {
                         const query = new URLSearchParams();
                         query.append("format", format);
-                        if (jobs != null && session !== "job") {
+                        if (jobs && session !== "job") {
                             query.append("jobs", jobs);
                         }
                         try {
@@ -593,7 +593,7 @@
                 const baseURL = `${backendAPI}/tasks/${id}/annotations/${encodeURIComponent(filename)}`;
                 const query = new URLSearchParams();
                 query.append("format", format);
-                if (jobs != null) {
+                if (jobs) {
                     query.append("jobs", jobs);
                 }
                 let url = `${baseURL}?${query}`;

--- a/cvat-core/src/session.js
+++ b/cvat-core/src/session.js
@@ -20,9 +20,9 @@
         Object.defineProperties(prototype, {
             annotations: Object.freeze({
                 value: {
-                    async upload(file, loader) {
+                    async upload(file, loader, jobs) {
                         const result = await PluginRegistry
-                            .apiWrapper.call(this, prototype.annotations.upload, file, loader);
+                            .apiWrapper.call(this, prototype.annotations.upload, file, loader, jobs);
                         return result;
                     },
 
@@ -38,9 +38,9 @@
                         return result;
                     },
 
-                    async dump(name, dumper) {
+                    async dump(name, dumper, jobs) {
                         const result = await PluginRegistry
-                            .apiWrapper.call(this, prototype.annotations.dump, name, dumper);
+                            .apiWrapper.call(this, prototype.annotations.dump, name, dumper, jobs);
                         return result;
                     },
 
@@ -1244,9 +1244,9 @@
             * @throws {module:API.cvat.exceptions.ServerError}
             * @throws {module:API.cvat.exceptions.PluginError}
         */
-        async validate() {
+        async validate(jobs) {
             const result = await PluginRegistry
-                .apiWrapper.call(this, Task.prototype.validate);
+                .apiWrapper.call(this, Task.prototype.validate, jobs);
             return result;
         }
 
@@ -1438,8 +1438,8 @@
         return result;
     };
 
-    Job.prototype.annotations.dump.implementation = async function (name, dumper) {
-        const result = await dumpAnnotations(this, name, dumper);
+    Job.prototype.annotations.dump.implementation = async function (name, dumper, jobs) {
+        const result = await dumpAnnotations(this, name, dumper, jobs);
         return result;
     };
 
@@ -1525,8 +1525,8 @@
         return result;
     };
 
-    Task.prototype.validate.implementation = async function () {
-        const result = await serverProxy.tasks.validateTask(this.id);
+    Task.prototype.validate.implementation = async function (jobs) {
+        const result = await serverProxy.tasks.validateTask(this.id, jobs);
         return result;
     };
 
@@ -1650,13 +1650,13 @@
         return result;
     };
 
-    Task.prototype.annotations.upload.implementation = async function (file, loader) {
-        const result = await uploadAnnotations(this, file, loader);
+    Task.prototype.annotations.upload.implementation = async function (file, loader, jobs) {
+        const result = await uploadAnnotations(this, file, loader, jobs);
         return result;
     };
 
-    Task.prototype.annotations.dump.implementation = async function (name, dumper) {
-        const result = await dumpAnnotations(this, name, dumper);
+    Task.prototype.annotations.dump.implementation = async function (name, dumper, jobs) {
+        const result = await dumpAnnotations(this, name, dumper, jobs);
         return result;
     };
 

--- a/cvat-core/src/user.js
+++ b/cvat-core/src/user.js
@@ -146,6 +146,9 @@
                 isAnnotator: {
                     get: () => data.groups.some(group => group === "annotator")
                 },
+                isAdmin: {
+                    get: () => data.is_staff || data.groups.some(group => group === "admin")
+                },
             }));
         }
     }

--- a/cvat-core/src/user.js
+++ b/cvat-core/src/user.js
@@ -143,6 +143,9 @@
                     */
                     get: () => data.is_active,
                 },
+                isAnnotator: {
+                    get: () => data.groups.some(group => group === "annotator")
+                },
             }));
         }
     }

--- a/cvat-ui/src/actions/tasks-actions.ts
+++ b/cvat-ui/src/actions/tasks-actions.ts
@@ -164,12 +164,12 @@ function dumpAnnotationFailed(task: any, dumper: any, error: any): AnyAction {
     return action;
 }
 
-export function dumpAnnotationsAsync(task: any, dumper: any):
+export function dumpAnnotationsAsync(task: any, dumper: any, jobs: any[] | null):
 ThunkAction<Promise<void>, {}, {}, AnyAction> {
     return async (dispatch: ActionCreator<Dispatch>): Promise<void> => {
         try {
             dispatch(dumpAnnotation(task, dumper));
-            const url = await task.annotations.dump(task.name, dumper);
+            const url = await task.annotations.dump(task.name, dumper, jobs);
             const downloadAnchor = (window.document.getElementById('downloadAnchor') as HTMLAnchorElement);
             downloadAnchor.href = url;
             downloadAnchor.click();
@@ -217,7 +217,7 @@ function loadAnnotationsFailed(task: any, error: any): AnyAction {
     return action;
 }
 
-export function loadAnnotationsAsync(task: any, loader: any, file: File):
+export function loadAnnotationsAsync(task: any, loader: any, file: File, jobs: any[] | null):
 ThunkAction<Promise<void>, {}, {}, AnyAction> {
     return async (dispatch: ActionCreator<Dispatch>): Promise<void> => {
         try {
@@ -227,7 +227,7 @@ ThunkAction<Promise<void>, {}, {}, AnyAction> {
                 throw Error('Only one loading of annotations for a task allowed at the same time');
             }
             dispatch(loadAnnotations(task, loader));
-            await task.annotations.upload(file, loader);
+            await task.annotations.upload(file, loader, jobs);
         } catch (error) {
             dispatch(loadAnnotationsFailed(task, error));
             return;

--- a/cvat-ui/src/components/actions-menu/actions-menu.tsx
+++ b/cvat-ui/src/components/actions-menu/actions-menu.tsx
@@ -20,6 +20,7 @@ interface Props {
     taskID: number;
     taskMode: string;
     bugTracker: string;
+    allowLoad: boolean;
 
     loaders: string[];
     dumpers: string[];
@@ -50,6 +51,7 @@ export default function ActionsMenuComponent(props: Props): JSX.Element {
         taskID,
         taskMode,
         bugTracker,
+        allowLoad,
 
         installedAutoAnnotation,
         installedTFAnnotation,
@@ -134,6 +136,7 @@ export default function ActionsMenuComponent(props: Props): JSX.Element {
                         onClickMenuWrapper(null, file);
                     },
                     menuKey: Actions.LOAD_TASK_ANNO,
+                    disabled: !allowLoad,
                 })
             }
             {

--- a/cvat-ui/src/components/actions-menu/load-submenu.tsx
+++ b/cvat-ui/src/components/actions-menu/load-submenu.tsx
@@ -18,6 +18,7 @@ interface Props {
     loaders: string[];
     loadActivity: string | null;
     onFileUpload(file: File): void;
+    disabled: boolean;
 }
 
 export default function LoadSubmenu(props: Props): JSX.Element {
@@ -26,10 +27,11 @@ export default function LoadSubmenu(props: Props): JSX.Element {
         loaders,
         loadActivity,
         onFileUpload,
+        disabled,
     } = props;
 
     return (
-        <Menu.SubMenu key={menuKey} title='Upload annotations'>
+        <Menu.SubMenu key={menuKey} title='Upload annotations' disabled={disabled}>
             {
                 loaders.map((_loader: string): JSX.Element => {
                     const [loader, accept] = _loader.split('::');
@@ -63,3 +65,7 @@ export default function LoadSubmenu(props: Props): JSX.Element {
         </Menu.SubMenu>
     );
 }
+
+LoadSubmenu.defaultProps = {
+    disabled: false,
+};

--- a/cvat-ui/src/components/task-page/job-list.tsx
+++ b/cvat-ui/src/components/task-page/job-list.tsx
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: MIT
 
-import React, { useState } from 'react';
+import React from 'react';
 
 import { RouteComponentProps } from 'react-router';
 import { withRouter } from 'react-router-dom';
@@ -32,6 +32,7 @@ interface Props {
     taskInstance: any;
     registeredUsers: any[];
     me: any;
+    onlyMine: boolean;
     onJobUpdate(jobInstance: any): void;
 }
 
@@ -40,12 +41,12 @@ function JobListComponent(props: Props & RouteComponentProps): JSX.Element {
         taskInstance,
         registeredUsers,
         me,
+        onlyMine,
         onJobUpdate,
         history: {
             push,
         },
     } = props;
-    const [onlyMine, setOnlyMine] = useState(false);
 
     const { jobs, id: taskId } = taskInstance;
     const columns = [{
@@ -191,12 +192,9 @@ function JobListComponent(props: Props & RouteComponentProps): JSX.Element {
                     </Tooltip>
                 </Col>
                 <Col>
-                    <Button
-                        type='link'
-                        onClick={() => setOnlyMine(value => !value)}
-                    >
+                    <Text className='cvat-text-color'>
                         {jobsMessage}
-                    </Button>
+                    </Text>
                 </Col>
             </Row>
             <Table

--- a/cvat-ui/src/components/task-page/styles.scss
+++ b/cvat-ui/src/components/task-page/styles.scss
@@ -75,6 +75,10 @@
     margin-bottom: 10px;
 }
 
+.cvat-task-top-bar div:first-child {
+  margin-right: auto;
+}
+
 .cvat-task-preview-wrapper {
     display: flex;
     justify-content: flex-start;

--- a/cvat-ui/src/components/task-page/task-page.tsx
+++ b/cvat-ui/src/components/task-page/task-page.tsx
@@ -32,6 +32,16 @@ interface TaskPageComponentProps {
 type Props = TaskPageComponentProps & RouteComponentProps<{id: string}>;
 
 class TaskPageComponent extends React.PureComponent<Props> {
+    public constructor(props: Props) {
+        super(props);
+
+        const { me } = this.props;
+        this.state = {
+            // By default show only user's own jobs for annotators, show all jobs for admins
+            onlyMine: me.isAnnotator,
+        };
+    }
+
     public componentDidUpdate(): void {
         const {
             deleteActivity,
@@ -49,6 +59,7 @@ class TaskPageComponent extends React.PureComponent<Props> {
             fetching,
             getTask,
         } = this.props;
+        const { onlyMine } = this.state;
 
         if (task === null) {
             if (!fetching) {
@@ -75,9 +86,13 @@ class TaskPageComponent extends React.PureComponent<Props> {
             <>
                 <Row type='flex' justify='center' align='top' className='cvat-task-details-wrapper'>
                     <Col md={22} lg={18} xl={16} xxl={14}>
-                        <TopBarComponent taskInstance={(task as Task).instance} />
+                        <TopBarComponent
+                            taskInstance={(task as Task).instance}
+                            setOnlyMine={(v) => this.setState({onlyMine: v})}
+                            onlyMine={onlyMine}
+                        />
                         <DetailsContainer task={(task as Task)} />
-                        <JobListContainer task={(task as Task)} />
+                        <JobListContainer task={(task as Task)} onlyMine={onlyMine}/>
                         <ValidationReportComponent taskInstance={(task as Task).instance} />
                     </Col>
                 </Row>

--- a/cvat-ui/src/components/task-page/task-page.tsx
+++ b/cvat-ui/src/components/task-page/task-page.tsx
@@ -83,7 +83,11 @@ class TaskPageComponent extends React.PureComponent<Props> {
             );
         }
 
-        const mineJobs = onlyMine ? task.instance.jobs.filter(j => (j.assignee || {}).id === me.id).map(j => j.id) : null;
+        const mineJobs = onlyMine ?
+            task.instance.jobs
+                .filter(j => (j.assignee || {}).id === me.id)
+                .map(j => j.id)
+            : null;
         const allowLoad = me.isAdmin | onlyMine;
 
         return (

--- a/cvat-ui/src/components/task-page/task-page.tsx
+++ b/cvat-ui/src/components/task-page/task-page.tsx
@@ -84,6 +84,7 @@ class TaskPageComponent extends React.PureComponent<Props> {
         }
 
         const mineJobs = onlyMine ? task.instance.jobs.filter(j => (j.assignee || {}).id === me.id).map(j => j.id) : null;
+        const allowLoad = me.isAdmin | onlyMine;
 
         return (
             <>
@@ -94,6 +95,7 @@ class TaskPageComponent extends React.PureComponent<Props> {
                             setOnlyMine={(v) => this.setState({onlyMine: v})}
                             onlyMine={onlyMine}
                             jobs={mineJobs}
+                            allowLoad={allowLoad}
                         />
                         <DetailsContainer task={(task as Task)} />
                         <JobListContainer task={(task as Task)} onlyMine={onlyMine}/>

--- a/cvat-ui/src/components/task-page/task-page.tsx
+++ b/cvat-ui/src/components/task-page/task-page.tsx
@@ -55,6 +55,7 @@ class TaskPageComponent extends React.PureComponent<Props> {
 
     public render(): JSX.Element {
         const {
+            me,
             task,
             fetching,
             getTask,
@@ -82,6 +83,8 @@ class TaskPageComponent extends React.PureComponent<Props> {
             );
         }
 
+        const mineJobs = onlyMine ? task.instance.jobs.filter(j => (j.assignee || {}).id === me.id).map(j => j.id) : null;
+
         return (
             <>
                 <Row type='flex' justify='center' align='top' className='cvat-task-details-wrapper'>
@@ -90,10 +93,11 @@ class TaskPageComponent extends React.PureComponent<Props> {
                             taskInstance={(task as Task).instance}
                             setOnlyMine={(v) => this.setState({onlyMine: v})}
                             onlyMine={onlyMine}
+                            jobs={mineJobs}
                         />
                         <DetailsContainer task={(task as Task)} />
                         <JobListContainer task={(task as Task)} onlyMine={onlyMine}/>
-                        <ValidationReportComponent taskInstance={(task as Task).instance} />
+                        <ValidationReportComponent taskInstance={(task as Task).instance} jobs={mineJobs} />
                     </Col>
                 </Row>
                 <ModelRunnerModalContainer />

--- a/cvat-ui/src/components/task-page/top-bar.tsx
+++ b/cvat-ui/src/components/task-page/top-bar.tsx
@@ -37,7 +37,7 @@ export default function DetailsComponent(props: DetailsComponentProps): JSX.Elem
                 <Text className='cvat-title'>{`Task details #${id}`}</Text>
             </Col>
             <Col>
-                <Tooltip title='Show, dump, upload, validate only mine jobs'>
+                <Tooltip title='Show, dump, upload, validate only my jobs'>
                     <Switch checked={onlyMine} onChange={setOnlyMine} />
                 </Tooltip>
             </Col>

--- a/cvat-ui/src/components/task-page/top-bar.tsx
+++ b/cvat-ui/src/components/task-page/top-bar.tsx
@@ -9,6 +9,8 @@ import {
     Col,
     Button,
     Dropdown,
+    Tooltip,
+    Switch,
     Icon,
 } from 'antd';
 
@@ -19,18 +21,25 @@ import { MenuIcon } from 'icons';
 
 interface DetailsComponentProps {
     taskInstance: any;
+    onlyMine: boolean;
+    setOnlyMine(value: boolean): void;
 }
 
 export default function DetailsComponent(props: DetailsComponentProps): JSX.Element {
-    const { taskInstance } = props;
+    const { taskInstance, onlyMine, setOnlyMine } = props;
     const { id } = taskInstance;
 
     return (
-        <Row className='cvat-task-top-bar' type='flex' justify='space-between' align='middle'>
+        <Row className='cvat-task-top-bar' type='flex' justify='end' align='middle'>
             <Col>
                 <Text className='cvat-title'>{`Task details #${id}`}</Text>
             </Col>
             <Col>
+                <Tooltip title='Show, dump, upload, validate only mine jobs'>
+                    <Switch checked={onlyMine} onChange={setOnlyMine} />
+                </Tooltip>
+            </Col>
+            <Col offset={1}>
                 <Dropdown overlay={
                     (
                         <ActionsMenuContainer

--- a/cvat-ui/src/components/task-page/top-bar.tsx
+++ b/cvat-ui/src/components/task-page/top-bar.tsx
@@ -23,10 +23,11 @@ interface DetailsComponentProps {
     taskInstance: any;
     onlyMine: boolean;
     setOnlyMine(value: boolean): void;
+    jobs: any[] | null;
 }
 
 export default function DetailsComponent(props: DetailsComponentProps): JSX.Element {
-    const { taskInstance, onlyMine, setOnlyMine } = props;
+    const { taskInstance, onlyMine, setOnlyMine, jobs } = props;
     const { id } = taskInstance;
 
     return (
@@ -44,6 +45,7 @@ export default function DetailsComponent(props: DetailsComponentProps): JSX.Elem
                     (
                         <ActionsMenuContainer
                             taskInstance={taskInstance}
+                            jobs={jobs}
                         />
                     )
                 }

--- a/cvat-ui/src/components/task-page/top-bar.tsx
+++ b/cvat-ui/src/components/task-page/top-bar.tsx
@@ -24,10 +24,11 @@ interface DetailsComponentProps {
     onlyMine: boolean;
     setOnlyMine(value: boolean): void;
     jobs: any[] | null;
+    allowLoad: boolean;
 }
 
 export default function DetailsComponent(props: DetailsComponentProps): JSX.Element {
-    const { taskInstance, onlyMine, setOnlyMine, jobs } = props;
+    const { taskInstance, onlyMine, setOnlyMine, jobs, allowLoad } = props;
     const { id } = taskInstance;
 
     return (
@@ -46,6 +47,7 @@ export default function DetailsComponent(props: DetailsComponentProps): JSX.Elem
                         <ActionsMenuContainer
                             taskInstance={taskInstance}
                             jobs={jobs}
+                            allowLoad={allowLoad}
                         />
                     )
                 }

--- a/cvat-ui/src/components/task-page/validation-report.tsx
+++ b/cvat-ui/src/components/task-page/validation-report.tsx
@@ -9,16 +9,17 @@ import Text from 'antd/lib/typography/Text';
 
 interface Props {
     taskInstance: any;
+    jobs: any[] | null;
 }
 
 function ValidationReportComponent(props: Props): JSX.Element {
     const [loading, setLoading] = useState(false);
     const [report, setReport] = useState(null);
-    const { taskInstance } = props;
+    const { taskInstance, jobs } = props;
 
     const loadData = () : void => {
       setLoading(true);
-      taskInstance.validate().then(responseData => {
+      taskInstance.validate(jobs).then(responseData => {
           setReport(responseData.report);
           setLoading(false);
       })

--- a/cvat-ui/src/components/tasks-page/task-item.tsx
+++ b/cvat-ui/src/components/tasks-page/task-item.tsx
@@ -29,6 +29,7 @@ export interface TaskItemProps {
     previewImage: string;
     deleted: boolean;
     hidden: boolean;
+    allowLoad: boolean;
     activeInference: ActiveInference | null;
     cancelAutoAnnotation(): void;
 }
@@ -177,6 +178,7 @@ class TaskItemComponent extends React.PureComponent<TaskItemProps & RouteCompone
         const {
             taskInstance,
             history,
+            allowLoad,
         } = this.props;
         const { id } = taskInstance;
 
@@ -198,7 +200,7 @@ class TaskItemComponent extends React.PureComponent<TaskItemProps & RouteCompone
                 <Row type='flex' justify='end'>
                     <Col className='cvat-item-open-task-actions'>
                         <Text className='cvat-text-color'>Actions</Text>
-                        <Dropdown overlay={<ActionsMenuContainer taskInstance={taskInstance} />}>
+                        <Dropdown overlay={<ActionsMenuContainer taskInstance={taskInstance} allowLoad={allowLoad} />}>
                             <Icon className='cvat-menu-icon' component={MenuIcon} />
                         </Dropdown>
                     </Col>

--- a/cvat-ui/src/components/tasks-page/task-list.tsx
+++ b/cvat-ui/src/components/tasks-page/task-list.tsx
@@ -18,17 +18,19 @@ export interface ContentListProps {
     currentTasksIndexes: number[];
     currentPage: number;
     numberOfTasks: number;
+    allowLoad: boolean;
 }
 
 export default function TaskListComponent(props: ContentListProps): JSX.Element {
     const {
+        allowLoad,
         currentTasksIndexes,
         numberOfTasks,
         currentPage,
         onSwitchPage,
     } = props;
     const taskViews = currentTasksIndexes.map(
-        (tid, id): JSX.Element => <TaskItem idx={id} taskID={tid} key={tid} />,
+        (tid, id): JSX.Element => <TaskItem idx={id} taskID={tid} key={tid} allowLoad={allowLoad} />,
     );
 
     return (

--- a/cvat-ui/src/containers/actions-menu/actions-menu.tsx
+++ b/cvat-ui/src/containers/actions-menu/actions-menu.tsx
@@ -22,6 +22,7 @@ import { ClickParam } from 'antd/lib/menu';
 interface OwnProps {
     taskInstance: any;
     jobs: any[] | null;
+    allowLoad: boolean;
 }
 
 interface StateToProps {
@@ -108,6 +109,7 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
 function ActionsMenuContainer(props: OwnProps & StateToProps & DispatchToProps): JSX.Element {
     const {
         jobs,
+        allowLoad,
         taskInstance,
         annotationFormats,
         exporters,
@@ -187,9 +189,14 @@ function ActionsMenuContainer(props: OwnProps & StateToProps & DispatchToProps):
             installedTFAnnotation={installedTFAnnotation}
             installedTFSegmentation={installedTFSegmentation}
             onClickMenu={onClickMenu}
+            allowLoad={allowLoad}
         />
     );
 }
+
+ActionsMenuContainer.defaultProps = {
+    allowLoad: true,
+};
 
 export default connect(
     mapStateToProps,

--- a/cvat-ui/src/containers/actions-menu/actions-menu.tsx
+++ b/cvat-ui/src/containers/actions-menu/actions-menu.tsx
@@ -21,6 +21,7 @@ import { ClickParam } from 'antd/lib/menu';
 
 interface OwnProps {
     taskInstance: any;
+    jobs: any[] | null;
 }
 
 interface StateToProps {
@@ -36,8 +37,8 @@ interface StateToProps {
 }
 
 interface DispatchToProps {
-    loadAnnotations: (taskInstance: any, loader: any, file: File) => void;
-    dumpAnnotations: (taskInstance: any, dumper: any) => void;
+    loadAnnotations: (taskInstance: any, loader: any, file: File, jobs: any[] | null) => void;
+    dumpAnnotations: (taskInstance: any, dumper: any, jobs: any[] | null) => void;
     exportDataset: (taskInstance: any, exporter: any) => void;
     deleteTask: (taskInstance: any) => void;
     openRunModelWindow: (taskInstance: any) => void;
@@ -86,11 +87,11 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
 
 function mapDispatchToProps(dispatch: any): DispatchToProps {
     return {
-        loadAnnotations: (taskInstance: any, loader: any, file: File): void => {
-            dispatch(loadAnnotationsAsync(taskInstance, loader, file));
+        loadAnnotations: (taskInstance: any, loader: any, file: File, jobs: any[] | null): void => {
+            dispatch(loadAnnotationsAsync(taskInstance, loader, file, jobs));
         },
-        dumpAnnotations: (taskInstance: any, dumper: any): void => {
-            dispatch(dumpAnnotationsAsync(taskInstance, dumper));
+        dumpAnnotations: (taskInstance: any, dumper: any, jobs: any[] | null): void => {
+            dispatch(dumpAnnotationsAsync(taskInstance, dumper, jobs));
         },
         exportDataset: (taskInstance: any, exporter: any): void => {
             dispatch(exportDatasetAsync(taskInstance, exporter));
@@ -106,6 +107,7 @@ function mapDispatchToProps(dispatch: any): DispatchToProps {
 
 function ActionsMenuContainer(props: OwnProps & StateToProps & DispatchToProps): JSX.Element {
     const {
+        jobs,
         taskInstance,
         annotationFormats,
         exporters,
@@ -139,14 +141,14 @@ function ActionsMenuContainer(props: OwnProps & StateToProps & DispatchToProps):
                 const [dumper] = dumpers
                     .filter((_dumper: any): boolean => _dumper.name === format);
                 if (dumper) {
-                    dumpAnnotations(taskInstance, dumper);
+                    dumpAnnotations(taskInstance, dumper, jobs);
                 }
             } else if (action === Actions.LOAD_TASK_ANNO) {
                 const [format] = additionalKey.split('::');
                 const [loader] = loaders
                     .filter((_loader: any): boolean => _loader.name === format);
                 if (loader && file) {
-                    loadAnnotations(taskInstance, loader, file);
+                    loadAnnotations(taskInstance, loader, file, jobs);
                 }
             } else if (action === Actions.EXPORT_TASK_DATASET) {
                 const format = additionalKey;

--- a/cvat-ui/src/containers/task-page/job-list.tsx
+++ b/cvat-ui/src/containers/task-page/job-list.tsx
@@ -14,6 +14,7 @@ import {
 
 interface OwnProps {
     task: Task;
+    onlyMine: boolean;
 }
 
 interface StateToProps {
@@ -42,6 +43,7 @@ function TaskPageContainer(props: StateToProps & DispatchToProps & OwnProps): JS
     const {
         task,
         me,
+        onlyMine,
         registeredUsers,
         onJobUpdate,
     } = props;
@@ -50,6 +52,7 @@ function TaskPageContainer(props: StateToProps & DispatchToProps & OwnProps): JS
         <JobListComponent
             taskInstance={task.instance}
             me={me}
+            onlyMine={onlyMine}
             registeredUsers={registeredUsers}
             onJobUpdate={onJobUpdate}
         />

--- a/cvat-ui/src/containers/task-page/task-page.tsx
+++ b/cvat-ui/src/containers/task-page/task-page.tsx
@@ -22,6 +22,7 @@ interface StateToProps {
     fetching: boolean;
     deleteActivity: boolean | null;
     installedGit: boolean;
+    me: any;
 }
 
 interface DispatchToProps {
@@ -33,6 +34,7 @@ function mapStateToProps(state: CombinedState, own: Props): StateToProps {
     const { tasks } = state;
     const { gettingQuery } = tasks;
     const { deletes } = tasks.activities;
+    const me = state.auth.user;
 
     const id = +own.match.params.id;
 
@@ -48,6 +50,7 @@ function mapStateToProps(state: CombinedState, own: Props): StateToProps {
     }
 
     return {
+        me,
         task,
         deleteActivity,
         fetching: state.tasks.fetching,

--- a/cvat-ui/src/containers/tasks-page/task-item.tsx
+++ b/cvat-ui/src/containers/tasks-page/task-item.tsx
@@ -22,6 +22,7 @@ interface StateToProps {
     previewImage: string;
     taskInstance: any;
     activeInference: ActiveInference | null;
+    allowLoad: boolean;
 }
 
 interface DispatchToProps {
@@ -32,6 +33,7 @@ interface DispatchToProps {
 interface OwnProps {
     idx: number;
     taskID: number;
+    allowLoad: boolean;
 }
 
 function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
@@ -45,6 +47,7 @@ function mapStateToProps(state: CombinedState, own: OwnProps): StateToProps {
         previewImage: task.preview,
         taskInstance: task.instance,
         activeInference: state.models.inferences[id] || null,
+        allowLoad: own.allowLoad,
     };
 }
 

--- a/cvat-ui/src/containers/tasks-page/tasks-list.tsx
+++ b/cvat-ui/src/containers/tasks-page/tasks-list.tsx
@@ -19,6 +19,7 @@ import {
 
 interface StateToProps {
     tasks: TasksState;
+    me: any;
 }
 
 interface DispatchToProps {
@@ -32,6 +33,7 @@ interface OwnProps {
 function mapStateToProps(state: CombinedState): StateToProps {
     return {
         tasks: state.tasks,
+        me: state.auth.user,
     };
 }
 
@@ -47,6 +49,7 @@ type TasksListContainerProps = StateToProps & DispatchToProps & OwnProps;
 
 function TasksListContainer(props: TasksListContainerProps): JSX.Element {
     const {
+        me,
         tasks,
         onSwitchPage,
     } = props;
@@ -57,6 +60,7 @@ function TasksListContainer(props: TasksListContainerProps): JSX.Element {
             currentTasksIndexes={tasks.current.map((task): number => task.instance.id)}
             currentPage={tasks.gettingQuery.page}
             numberOfTasks={tasks.count}
+            allowLoad={me.isAdmin}
         />
     );
 }

--- a/cvat-ui/src/styles.scss
+++ b/cvat-ui/src/styles.scss
@@ -18,6 +18,10 @@ hr {
     margin: 10% 25%;
 }
 
+.cvat-text-color {
+    color: $text-color;
+}
+
 .cvat-title {
     font-weight: 400;
     font-size: 21px;

--- a/cvat/apps/annotation/transports/cvat/importer.py
+++ b/cvat/apps/annotation/transports/cvat/importer.py
@@ -14,9 +14,9 @@ class CVATImporter:
         self._logger = logger
 
     @classmethod
-    def for_task(cls, task_id, logger=None):
+    def for_task(cls, task_id, job_ids=(), logger=None):
         with transaction.atomic():
-            annotation = TaskAnnotation(task_id, AnonymousUser())
+            annotation = TaskAnnotation(task_id, AnonymousUser(), job_ids)
             annotation.init_from_db()
 
         anno_exporter = Annotation(

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -9,6 +9,7 @@ import shutil
 from rest_framework import serializers
 from django.contrib.auth.models import User, Group
 
+from cvat.apps.annotation.models import AnnotationDumper
 from cvat.apps.engine import models
 from cvat.apps.engine.log import slogger
 
@@ -205,6 +206,16 @@ class DataOptionsSerializer(serializers.Serializer):
         if data['assignees'] and data['chunk_size'] is None:
             raise serializers.ValidationError("When assignees are provided chunk size should be provided as well")
         return data
+
+
+class TaskDumpSerializer(serializers.Serializer):
+    action = serializers.CharField(default=None)
+    format = serializers.SlugRelatedField('display_name', queryset=AnnotationDumper.objects.all())
+
+    def validate_action(self, value):
+        if value not in [None, "download"]:
+            raise serializers.ValidationError("Please specify a correct 'action' for the request")
+        return value
 
 
 class WriteOnceMixin:

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -208,7 +208,13 @@ class DataOptionsSerializer(serializers.Serializer):
         return data
 
 
-class TaskDumpSerializer(serializers.Serializer):
+class JobsSelectionSerializer(serializers.Serializer):
+    jobs = CommaSeparatedValuesField(
+        child=serializers.IntegerField(min_value=1),
+        default=[],
+    )
+
+class TaskDumpSerializer(JobsSelectionSerializer):
     action = serializers.CharField(default=None)
     format = serializers.SlugRelatedField('display_name', queryset=AnnotationDumper.objects.all())
 

--- a/cvat/apps/engine/static/engine/js/base.js
+++ b/cvat/apps/engine/static/engine/js/base.js
@@ -134,10 +134,12 @@ async function dumpAnnotationRequest(tid, taskName, format) {
     // URL Router on the server doesn't work correctly with slashes.
     // So, we have to replace them on the client side
     taskName = taskName.replace(/\//g, '_');
-    const name = encodeURIComponent(`${tid}_${taskName}`);
+    const name = encodeURIComponent(taskName);
     return new Promise((resolve, reject) => {
         const url = `/api/v1/tasks/${tid}/annotations/${name}`;
-        let queryString = `format=${format}`;
+        const queryString = new URLSearchParams();
+        queryString.append("format", format);
+        queryString.append("jobs", [window.cvat.job.id]);
 
         async function request() {
             $.get(`${url}?${queryString}`)
@@ -146,7 +148,7 @@ async function dumpAnnotationRequest(tid, taskName, format) {
                         setTimeout(request, 3000);
                     } else {
                         const a = document.createElement('a');
-                        queryString = `${queryString}&action=download`;
+                        queryString.append("action", "download");
                         a.href = `${url}?${queryString}`;
                         document.body.appendChild(a);
                         a.click();


### PR DESCRIPTION
Extra feature for https://p.daedalean.ai/T6020

When multiple annotators are working on the same task, it's confusing when dump and validate processes all jobs (even those which are not assigned to the current user) and it's not safe to upload to the whole task as it might overwrite other annotators' data.