### PR TITLE
Change jump_threshold, rq timeout, fix empty files generation on partial dump

### DIFF
--- a/cvat/apps/annotation/annotation.py
+++ b/cvat/apps/annotation/annotation.py
@@ -111,7 +111,7 @@ class Annotation:
     Tag.__new__.__defaults__ = (0, )
     Frame = namedtuple('Frame', 'frame, name, width, height, labeled_shapes, tags')
 
-    def __init__(self, annotation_ir, db_task, scheme='', host='', create_callback=None):
+    def __init__(self, annotation_ir, db_task, scheme='', host='', create_callback=None, frames_set=None):
         self._annotation_ir = annotation_ir
         self._db_task = db_task
         self._scheme = scheme
@@ -142,7 +142,7 @@ class Annotation:
                 **attr_mapping['immutable'],
             }
 
-        self._init_frame_info()
+        self._init_frame_info(frames_set)
         self._init_meta()
 
     def _get_label_id(self, label_name):
@@ -176,7 +176,7 @@ class Annotation:
     def _get_immutable_attribute_id(self, label_id, attribute_name):
         return self._get_attribute_id(label_id, attribute_name, 'immutable')
 
-    def _init_frame_info(self):
+    def _init_frame_info(self, frames_set):
         if self._db_task.mode == "interpolation":
             self._frame_info = {
                 frame: {
@@ -191,6 +191,9 @@ class Annotation:
                 "width": db_image.width,
                 "height": db_image.height,
             } for db_image in self._db_task.image_set.all()}
+
+        if frames_set:
+            self._frame_info = {frame: info for frame, info in self._frame_info.items() if frame in frames_set}
 
         self._frame_mapping = {
             self._get_filename(info["path"]): frame for frame, info in self._frame_info.items()

--- a/cvat/apps/annotation/transports/cvat/importer.py
+++ b/cvat/apps/annotation/transports/cvat/importer.py
@@ -25,6 +25,7 @@ class CVATImporter:
             db_task=annotation.db_task,
             scheme='https',
             host='',
+            frames_set=annotation.get_frames_set(),
         )
         return cls(anno_exporter, logger)
 

--- a/cvat/apps/annotation/validation.py
+++ b/cvat/apps/annotation/validation.py
@@ -4,7 +4,7 @@ from itertools import groupby
 from cvat.apps.annotation.structures import BoundingBox, label_by_class_id
 
 
-def validate(sequences):
+def validate(sequences, jump_threshold=10):
     reporter = ValidationReporter()
     for seq in sequences:
         reporter.sequence = seq.name
@@ -30,7 +30,7 @@ def validate(sequences):
                 _validate_coordinates(bbox, reporter)
                 _validate_attributes(bbox, reporter)
                 _validate_class_immutability(bbox, class_id_by_track_id, reporter)
-                _validate_position_change(bbox, previous_frame, jump_threshold=2, reporter=reporter)
+                _validate_position_change(bbox, previous_frame, jump_threshold, reporter)
 
             reporter.bbox_index = None
             for track_id in duplicated_track_ids:

--- a/cvat/apps/engine/annotation.py
+++ b/cvat/apps/engine/annotation.py
@@ -667,6 +667,13 @@ class TaskAnnotation:
     def reset(self):
         self.ir_data.reset()
 
+    def get_frames_set(self):
+        result = set()
+        for job in self.db_jobs:
+            segment_frames = range(job.segment.start_frame, job.segment.stop_frame + 1)
+            result = result.union(segment_frames)
+        return result
+
     def _patch_data(self, data, action):
         _data = data if isinstance(data, AnnotationIR) else AnnotationIR(data)
         splitted_data = {}
@@ -727,6 +734,7 @@ class TaskAnnotation:
             db_task=self.db_task,
             scheme=scheme,
             host=host,
+            frames_set=self.get_frames_set(),
         )
         db_format = dumper.annotation_format
 

--- a/cvat/apps/engine/serializers.py
+++ b/cvat/apps/engine/serializers.py
@@ -222,6 +222,11 @@ class JobsSelectionSerializer(serializers.Serializer):
         default=[],
     )
 
+
+class TaskValidateSerializer(JobsSelectionSerializer):
+    jump_threshold = serializers.FloatField(required=False, min_value=1.0)
+
+
 class TaskDumpSerializer(JobsSelectionSerializer):
     action = serializers.CharField(default=None)
     format = serializers.SlugRelatedField('display_name', queryset=AnnotationDumper.objects.all())

--- a/cvat/settings/base.py
+++ b/cvat/settings/base.py
@@ -248,7 +248,7 @@ RQ_QUEUES = {
         'HOST': 'localhost',
         'PORT': 6379,
         'DB': 0,
-        'DEFAULT_TIMEOUT': '4h'
+        'DEFAULT_TIMEOUT': '8h'
     },
     'low': {
         'HOST': 'localhost',


### PR DESCRIPTION
Change jump_threshold value from 2 to 10 to decrease false-positive rate (allow to pass it through query params for debug purposes).

Change rq timeout from 4h to 8h to allow large task creation.

Fix directories with empty csv files being created for omitted sequences on partial dumps (when single job is dumped or when only user's jobs are dumped).