### PR TITLE
Group non-annotators at the end of assignees drop-down

### DIFF
--- a/cvat-ui/src/components/create-task-page/advanced-configuration-form.tsx
+++ b/cvat-ui/src/components/create-task-page/advanced-configuration-form.tsx
@@ -116,7 +116,10 @@ class AdvancedConfigurationForm extends React.PureComponent<Props> {
     }
 
     private renderAssigneesSelector(): JSX.Element {
-        const { form, users } = this.props;
+        let { form, users } = this.props;
+        users = [...users].sort((a, b) => a.username.localeCompare(b.username));
+        const annotators = users.filter(u => u.isAnnotator);
+        const others = users.filter(u => !u.isAnnotator);
 
         return (
             <Form.Item label={<span>Assign annotators</span>}>
@@ -125,11 +128,18 @@ class AdvancedConfigurationForm extends React.PureComponent<Props> {
                         initialValue: [],
                     })(
                         <Select mode='multiple' size='large'>
-                            { users.map((user): JSX.Element => (
+                            { annotators.map((user): JSX.Element => (
                                 <Select.Option key={user.id} value={user.id}>
                                     {user.username}
                                 </Select.Option>
                             ))}
+                            <Select.OptGroup label="Others">
+                                { others.map((user): JSX.Element => (
+                                    <Select.Option key={user.id} value={user.id}>
+                                        {user.username}
+                                    </Select.Option>
+                                ))}
+                            </Select.OptGroup>
                         </Select>,
                     )}
                 </Tooltip>


### PR DESCRIPTION
Sort users in assignee drop-down and group non-annotators (basically, admins) at the end of drop-down so it's easier to select right users.