### PR TITLE
Ui productivity enhancements

### DIFF
--- a/cvat/apps/annotation/ddln_spotter.py
+++ b/cvat/apps/annotation/ddln_spotter.py
@@ -93,7 +93,7 @@ def dump(file_object, annotations):
                     log_file.write("Converted data: {}".format(csv_line))
 
                 csv_file_name, dir_name = parse_frame_name(image_name)
-                csv_file_name += ".csv"
+                csv_file_name += "_y.csv"
                 dir_name = dir_name or "dummpy"
                 dir_name = os.path.join(temp_dir, dir_name)
                 log_file.write("Dir: {}; Added to file: {}\n".format(dir_name, csv_file_name))

--- a/cvat/apps/engine/static/engine/js/labelsInfo.js
+++ b/cvat/apps/engine/static/engine/js/labelsInfo.js
@@ -30,6 +30,7 @@ class LabelsInfo {
 
             for (const attr of label.attributes) {
                 this._attributes[attr.id] = convertAttribute(attr);
+                this._attributes[attr.id].defaultValue = this._attributes[attr.id].values[0];
                 this._labels[label.id].attributes[attr.id] = this._attributes[attr.id];
             }
 
@@ -94,6 +95,14 @@ class LabelsInfo {
             return JSON.parse(JSON.stringify(this._attributes[attrId]));
         }
         throw Error('Unknown attribute ID');
+    }
+
+
+    updateDefaultValue(attrId, attrValue) {
+        if (!(attrId in this._attributes)) {
+            throw Error('Unknown attribute ID');
+        }
+        this._attributes[attrId].defaultValue = attrValue;
     }
 
 

--- a/cvat/apps/engine/static/engine/js/player.js
+++ b/cvat/apps/engine/static/engine/js/player.js
@@ -706,6 +706,7 @@ class PlayerView {
         this._playerStepUI = $('#playerStep');
         this._playerSpeedUI = $('#speedSelect');
         this._playerGammaUI = $('#playerGammaRange');
+        this._showShapesSizesUI = $('#show-shape-sizes');
         this._resetZoomUI = $('#resetZoomBox');
         this._frameNumber = $('#frameNumber');
         this._playerGridPattern = $('#playerGridPattern');
@@ -739,6 +740,14 @@ class PlayerView {
                 this._controller.frameMouseDown(e);
             }
             e.preventDefault();
+        });
+
+        this._showShapesSizesUI.on('change', (e) => {
+            if (e.target.checked) {
+                $(document.body).removeClass('hide-box-size');
+            } else {
+                $(document.body).addClass('hide-box-size');
+            }
         });
 
         this._playerContentUI.on('wheel', e => this._controller.zoom(e, this._playerBackgroundUI[0]));

--- a/cvat/apps/engine/static/engine/js/player.js
+++ b/cvat/apps/engine/static/engine/js/player.js
@@ -113,8 +113,8 @@ class PlayerModel extends Listener {
             multipleStep: 10,
             fps: 25,
             gamma: 1,
-            rotateAll: task.mode === 'interpolation',
-            resetZoom: task.mode === 'annotation',
+            rotateAll: true,
+            resetZoom: false,
         };
 
         this._playInterval = null;

--- a/cvat/apps/engine/static/engine/js/shapeCollection.js
+++ b/cvat/apps/engine/static/engine/js/shapeCollection.js
@@ -1177,6 +1177,9 @@ class ShapeCollectionView {
         this._colorSettings = {
             'fill-opacity': 0,
             'projection-lines':false,
+            'color-by-label': true,
+            'color-by-group': false,
+            'colors-by-label': this._controller.colorsByGroup.bind(this._controller),
         };
 
         this._showAllInterpolationBox.on('change', (e) => {

--- a/cvat/apps/engine/static/engine/js/shapes.js
+++ b/cvat/apps/engine/static/engine/js/shapes.js
@@ -71,9 +71,9 @@ class ShapeModel extends Listener {
             let attrInfo = labelsInfo.attrInfo(attrId);
             if (attrInfo.mutable) {
                 this._attributes.mutable[this._frame] = this._attributes.mutable[this._frame] || {};
-                this._attributes.mutable[this._frame][attrId] = attrInfo.values[0];
+                this._attributes.mutable[this._frame][attrId] = attrInfo.defaultValue;
             } else {
-                this._attributes.immutable[attrId] = attrInfo.values[0];
+                this._attributes.immutable[attrId] = attrInfo.defaultValue;
             }
         }
 
@@ -267,12 +267,14 @@ class ShapeModel extends Listener {
         }, frame);
         // End of undo/redo code
 
+        const attrValue = LabelsInfo.normalize(attrInfo.type, value);
+        labelsInfo.updateDefaultValue(attrId, attrValue);
         if (attrInfo.mutable) {
             this._attributes.mutable[frame] = this._attributes.mutable[frame]|| {};
-            this._attributes.mutable[frame][attrId] = LabelsInfo.normalize(attrInfo.type, value);
+            this._attributes.mutable[frame][attrId] = attrValue;
             this._setupKeyFrames();
         } else {
-            this._attributes.immutable[attrId] = LabelsInfo.normalize(attrInfo.type, value);
+            this._attributes.immutable[attrId] = attrValue;
         }
 
         this.notify('attributes');

--- a/cvat/apps/engine/static/engine/stylesheet.css
+++ b/cvat/apps/engine/static/engine/stylesheet.css
@@ -263,6 +263,10 @@
     cursor: default;
 }
 
+body.hide-box-size .shapeText {
+    display: none;
+}
+
 .highlightedShape {
     fill-opacity: 0.2;
     stroke-opacity: 1;

--- a/cvat/apps/engine/templates/engine/annotation.html
+++ b/cvat/apps/engine/templates/engine/annotation.html
@@ -205,6 +205,10 @@
                         </div>
                     </td>
                     <td style="width: auto;">
+                        <div style="float: left;"> <label for="show-shape-sizes" class="semiBold"> Show shapes sizes: </label> </div>
+                        <div style="float: left; margin-left: 1em;"> <input type="checkbox" checked id="show-shape-sizes"> </div>
+                    </td>
+                    <td style="width: auto;">
                         <div style="float: left;"> <label for="playerGammaRange" class="semiBold"> Gamma: </label> </div>
                         <div style="float: left; margin-left: 1em;"> <input type="range" min="0.1" max="1" value="1" step="0.05" id="playerGammaRange"> </div>
                     </td>

--- a/cvat/apps/engine/templates/engine/annotation.html
+++ b/cvat/apps/engine/templates/engine/annotation.html
@@ -187,7 +187,7 @@
                         <div style="float: left;"> <label class="semiBold"> Color by: </label> </div>
                         <div style="float: left; margin-left: 10px;">
                             <label style="margin-right: 10px;"> Instance </label>
-                            <input type="radio" name="colorByRadio" id="colorByInstanceRadio" checked class="settingsBox"/>
+                            <input type="radio" name="colorByRadio" id="colorByInstanceRadio" class="settingsBox"/>
                         </div>
                         <div style="float: left; margin-left: 10px;">
                             <label style="margin-right: 10px;"> Group </label>
@@ -195,7 +195,7 @@
                         </div>
                         <div style="float: left; margin-left: 10px;">
                             <label style="margin-right: 10px;"> Label </label>
-                            <input type="radio" name="colorByRadio" id="colorByLabelRadio" class="settingsBox"/>
+                            <input type="radio" name="colorByRadio" id="colorByLabelRadio" checked class="settingsBox"/>
                         </div>
                         <div style="float: left; margin-left: 50px;" title="Press Ctrl to switch">
                             <label style="display: none;">


### PR DESCRIPTION
Some productivity enhancements requested by the annotators.

Change the default value of 'ResetZoom' to false.
Change the default value of 'rotateAll' to true.
Change the default value of 'Color by' to 'by label'.

Allow to hide shapes size by clicking on checkbox.

Make default values for attributes "sticky".
When annotators change attribute (e.g. "track_id") value, the selected value is stored and used as default value for newly created shapes. So annotators don't have to re-select "track_id" on each frame for the same object, they select it only on the first frame.

Also fix small bug with csv name generation (caused by refactoring in one of previous PRs).
