### PR TITLE
set node version

### DIFF
--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM node:lts-alpine AS cvat-ui
+FROM node:erbium-alpine AS cvat-ui
 
 ARG http_proxy
 ARG https_proxy

--- a/Dockerfile.ui
+++ b/Dockerfile.ui
@@ -1,4 +1,4 @@
-FROM node:erbium-alpine AS cvat-ui
+FROM node:12-alpine AS cvat-ui
 
 ARG http_proxy
 ARG https_proxy


### PR DESCRIPTION
set the node version we need explicitly.

v4.13.0 of node-sass does not support node ABI version > 79 (check https://nodejs.org/en/download/releases/ for node version and ABI numbers). erbium (node 12) is the latest supported version by that version of node-sass.