### PR TITLE
Initialize mode for external tasks

### DIFF
--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -331,6 +331,7 @@ def _create_thread(tid, data, options):
             assert len(db_images) == 0
             db_images = list(models.Image.objects.filter(task=db_task).order_by('frame'))
             db_task.size = len(db_images)
+            db_task.mode = 'interpolation'
         else:
             models.Image.objects.bulk_create(db_images)
 

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -331,7 +331,7 @@ def _create_thread(tid, data, options):
             assert len(db_images) == 0
             db_images = list(models.Image.objects.filter(task=db_task).order_by('frame'))
             db_task.size = len(db_images)
-            db_task.mode = 'interpolation'
+            db_task.mode = 'annotation'
         else:
             models.Image.objects.bulk_create(db_images)
 


### PR DESCRIPTION
For usual cvat tasks `task.mode` is initialized in for loop over all local task images, since external tasks don't have local images, their `mode` is left uninitialized.
