### PR TITLE
Vls lines export to grey

### DIFF
--- a/cvat/apps/engine/ddln/grey_export.py
+++ b/cvat/apps/engine/ddln/grey_export.py
@@ -46,7 +46,7 @@ def export_single_annotation(task, task_type):
         exporter = CsvDirectoryExporter(root_dir, clear_if_exists=False)
         migrate(importer, exporter, handler)
 
-        sequences = handler.load_sequences(CsvDirectoryImporter(root_dir))
+        sequences = handler.load_sequences(CsvDirectoryImporter(root_dir), 1, 1)
         reporter = handler.validate(sequences)
         if reporter.has_violations(reporter.severity.ERROR):
             raise ExportError("Task has validation errors. Please run the validation.")

--- a/cvat/apps/engine/ddln/tasks/handler.py
+++ b/cvat/apps/engine/ddln/tasks/handler.py
@@ -15,9 +15,9 @@ class TaskHandler(abc.ABC):
     def load_sequences(self, importer, image_width=None, image_height=None):
         frames_by_sequence_name = defaultdict(list)
         for frame_reader in importer.iterate_frames():
-            if image_width:
+            if not getattr(frame_reader, "image_width", None) and image_width:
                 frame_reader.image_width = image_width
-            if image_height:
+            if not getattr(frame_reader, "image_height", None) and image_height:
                 frame_reader.image_height = image_height
             frame_index = getattr(frame_reader, "index", None)
             self.begin_frame(frame_reader.sequence_name, frame_reader.name, frame_index)

--- a/cvat/apps/engine/ddln/tasks/vls_lines/validation.py
+++ b/cvat/apps/engine/ddln/tasks/vls_lines/validation.py
@@ -37,7 +37,7 @@ class VlsLinesValidationReporter(BaseValidationReporter):
         self._report("Runway {!r} lacks {} rays".format(runway_id, type), severity)
 
     def report_id_changed(self, previous, current):
-        self._report("Runway id has changed from {} to {}".format(previous, current))
+        self._report("Runway id has changed from {} to {}".format(previous, current), self.severity.WARNING)
 
     def report_lat_disorder(self):
         self._report("Lateral rays are mixed up")
@@ -49,4 +49,4 @@ class VlsLinesValidationReporter(BaseValidationReporter):
         self._report("Wrong values amount. Expected: {}, actual: {}".format(expected, actual))
 
     def report_not_crossing(self, error):
-        self._report("Lines seem not to cross at the same point. Error: {}".format(error))
+        self._report("Lines seem not to cross at the same point. Error: {}".format(error), self.severity.WARNING)

--- a/cvat/apps/engine/task.py
+++ b/cvat/apps/engine/task.py
@@ -356,8 +356,10 @@ def _create_thread(tid, data, options):
     make_image_meta_cache(db_task)
     job.meta['status'] = 'Finishing task creation...'
     job.save_meta()
-    handler = create_task_handler(guess_task_type(db_task))
-    handler.finalize_task_creation(db_task)
+    task_type = guess_task_type(db_task)
+    if task_type is not None:
+        handler = create_task_handler(task_type)
+        handler.finalize_task_creation(db_task)
     record_task_creation(db_task, segments)
 
 


### PR DESCRIPTION
Fix error being raised on grey export for vls tasks because image width and height were not initialized.
Lower severity for some checks so they won't prohibit task export.
Fix error being raised on task creation when it doesn't have known labels (then task type cannot be determined).
