### PR TITLE
Vls visibility check

### DIFF
--- a/cvat/apps/engine/ddln/tasks/validation.py
+++ b/cvat/apps/engine/ddln/tasks/validation.py
@@ -35,19 +35,19 @@ class BaseValidationReporter:
         for sequence in data['violations']:
             file.write("Sequence {}:\n".format(sequence["name"]))
             for seq_message in sequence["messages"]:
-                file.write("\t\t{}\n".format(seq_message))
+                file.write("    {}\n".format(seq_message))
             for frame in sequence["frames"]:
-                file.write("\tFrame {}:\n".format(frame["name"]))
+                file.write("  Frame {}:\n".format(frame["name"]))
                 for frame_message in frame["messages"]:
-                    file.write("\t\t{}\n".format(frame_message))
+                    file.write("    {}\n".format(frame_message))
                 for obj in frame["objects"]:
                     for message in obj["messages"]:
-                        file.write("\t\t{} {}: {}\n".format(self.object_name, obj["index"], message))
+                        file.write("    {} {}: {}\n".format(self.object_name, obj["index"], message))
         file.write("Frame counts per sequence:\n")
         count_per_sequence = data['counts']['perSequence'].items()
         count_per_sequence = sorted(count_per_sequence, key=lambda e: natural_order(e[0]))
         for sequence, count in count_per_sequence:
-            file.write("\t{}: {}\n".format(sequence, count))
+            file.write("  {}: {}\n".format(sequence, count))
         file.write("Total frames: {}\n".format(data['counts']['total']))
 
     def get_text_report(self, severity=Severity.ERROR):

--- a/cvat/apps/engine/ddln/tasks/validation.py
+++ b/cvat/apps/engine/ddln/tasks/validation.py
@@ -63,13 +63,20 @@ class BaseValidationReporter:
     def count_frame(self, sequence_name):
         self._frames_count_by_sequence[sequence_name] = self._frames_count_by_sequence.get(sequence_name, 0) + 1
 
-    def _report(self, message, severity=Severity.ERROR):
+    @property
+    def frame_name(self):
         frame_name = self.frame
         if self.frame_index is not None:
             index = "({})".format(self.frame_index)
             index = index.rjust(6, ' ')
             frame_name = "{}{}".format(frame_name, index)
-        self._violations.append((self.sequence, frame_name, self.object_index, message, severity))
+        return frame_name
+
+    def _report_sequence_message(self, message, severity=Severity.ERROR):
+        self._violations.append((self.sequence, None, None, message, severity))
+
+    def _report(self, message, severity=Severity.ERROR):
+        self._violations.append((self.sequence, self.frame_name, self.object_index, message, severity))
 
 
 def _group_violations(data, severity):

--- a/cvat/apps/engine/ddln/tasks/vls_lines/models.py
+++ b/cvat/apps/engine/ddln/tasks/vls_lines/models.py
@@ -67,6 +67,23 @@ class Runway:
         if not designator_visible:
             self.designator_line = None
 
+    def get_invisible_lines(self):
+        result = []
+        if self.left_line is None:
+            result.append("left edge")
+        if self.right_line is None:
+            result.append("right edge")
+        if self.center_line is None:
+            result.append("central line")
+        if self.start_line is None:
+            result.append("beginning")
+        if self.designator_line is None:
+            result.append("designator")
+        if self.end_line is None:
+            result.append("end")
+        return tuple(result)
+
+
     def _check_lon_order(self, reporter):
         # end line is intentionally omitted to avoid false-positives
         lat_lines = [self.start_line, self.designator_line]

--- a/cvat/apps/engine/ddln/tasks/vls_lines/persistence/cvat.py
+++ b/cvat/apps/engine/ddln/tasks/vls_lines/persistence/cvat.py
@@ -36,8 +36,6 @@ def iterate_runways(reader, reporter):
         reporter.report_missing_rays(runway_id, is_lon=True)
 
     for runway_id, lon in lons.items():
-        if runway_id not in lats:
-            reporter.report_missing_rays(runway_id, is_lon=False)
         lat = lats.get(runway_id)
         try:
             yield _parse_rays(lon, lat, reporter)

--- a/cvat/apps/engine/ddln/tasks/vls_lines/validation.py
+++ b/cvat/apps/engine/ddln/tasks/vls_lines/validation.py
@@ -1,4 +1,49 @@
+from abc import abstractmethod, ABC
+
 from ..validation import BaseValidationReporter
+
+
+class AggregatedCheck(ABC):
+    severity = BaseValidationReporter.severity.ERROR
+    ignored_values = set()
+
+    @abstractmethod
+    def format_message(self, runway_id, value, start, end):
+        ...
+
+    def __init__(self, reporter):
+        self._reporter = reporter
+        self._prev_values = {}
+        self._start_frame = {}
+        self._end_frame = {}
+        self._records = []
+
+    def __setitem__(self, runway_id, value):
+        current_frame = self._reporter.frame_name
+        prev_value = self._prev_values.get(runway_id)
+        if value != prev_value:
+            if prev_value is not None:
+                self._records.append((runway_id, prev_value, self._start_frame[runway_id], self._end_frame[runway_id]))
+            self._start_frame[runway_id] = current_frame
+        self._end_frame[runway_id] = current_frame
+        self._prev_values[runway_id] = value
+
+    def report(self):
+        for runway_id in self._prev_values.keys():
+            self[runway_id] = None
+        for runway_id, value, start, end in self._records:
+            if value in self.ignored_values:
+                continue
+            message = self.format_message(runway_id, value, start, end)
+            self._reporter._report_sequence_message(message, self.severity)
+
+
+class MissingLateralRaysCheck(AggregatedCheck):
+    severity = BaseValidationReporter.severity.WARNING
+    ignored_values = {False}
+
+    def format_message(self, runway_id, value, start, end):
+        return "{} - {}: Runway {!r} lacks lateral rays".format(start, end, runway_id)
 
 
 def validate(sequences, reporter=None, **kwargs):
@@ -7,6 +52,7 @@ def validate(sequences, reporter=None, **kwargs):
     for seq in sequences:
         reporter.sequence = seq.name
         previous_id = None
+        lateral_check = MissingLateralRaysCheck(reporter)
 
         for frame in seq.frames:
             reporter.frame = frame.name
@@ -14,10 +60,13 @@ def validate(sequences, reporter=None, **kwargs):
             reporter.count_frame(seq.name)
 
             for runway in frame.objects:
+                has_lateral_rays = any(line is not None for line in [runway.start_line, runway.end_line, runway.designator_line])
+                lateral_check[runway.id] = not has_lateral_rays
                 current_id = runway.id
                 if previous_id and current_id != previous_id:
                     reporter.report_id_changed(previous_id, current_id)
                 previous_id = current_id
+        lateral_check.report()
     return reporter
 
 

--- a/cvat/apps/engine/ddln/tasks/vls_lines/validation.py
+++ b/cvat/apps/engine/ddln/tasks/vls_lines/validation.py
@@ -9,7 +9,7 @@ class AggregatedCheck(ABC):
 
     @abstractmethod
     def format_message(self, runway_id, value, start, end):
-        ...
+        pass
 
     def __init__(self, reporter):
         self._reporter = reporter


### PR DESCRIPTION
Show visibility info in logs in order to prevent manual errors:
![res](https://user-images.githubusercontent.com/14096024/104813257-1c783a00-5819-11eb-8c5c-d779631f258d.png)
Aggregate missing lateral rays messages in order for output to be less verbose.
Before:
![before](https://user-images.githubusercontent.com/14096024/104813250-08343d00-5819-11eb-87d9-a2431353298c.png)
After:
![after](https://user-images.githubusercontent.com/14096024/104813253-0cf8f100-5819-11eb-9fc5-a96743f4e1ad.png)
