### PR TITLE
Handle case when some cameras don't exist

### DIFF
--- a/cvat-ui/src/components/file-manager/external-image-selector.tsx
+++ b/cvat-ui/src/components/file-manager/external-image-selector.tsx
@@ -130,7 +130,7 @@ function fetchRecordingData(recordingName) {
 function processRecordingData(data) {
     return data.record.cam.map(item => {
         const { width, height } = item.params;
-        const sourceFrames = item.abs_timestamp_ns;
+        const sourceFrames = item.abs_timestamp_ns || [];
         const frames = sourceFrames.map(padFrameName);
         return { width, height, frames, sourceFrames };
     });


### PR DESCRIPTION
When some of cameras are omitted (e.g. there are only cameras 0 and 2) non-existent cameras don't have `abs_timestamp_ns` field which leads to an error. Fix it by defaulting to an empty array (it is not used later anyway).