### PR TITLE
Rays fixes

### DIFF
--- a/cvat/apps/engine/static/engine/js/shapes.js
+++ b/cvat/apps/engine/static/engine/js/shapes.js
@@ -1344,7 +1344,7 @@ class RaysModel extends PolyShapeModel {
         const segmentIndex = Math.floor(idx/2);
         let frame = window.cvat.player.frames.current;
         let position = this._interpolatePosition(frame);
-        let [segments, vanishingPoint] = RaysModel.loadFromPoints(points);
+        let [segments, vanishingPoint] = RaysModel.loadFromPoints(position.points);
         if (segments.length > 1) {
             segments.splice(segmentIndex, 1);
             position.points = RaysModel.dumpToPoints(segments, vanishingPoint);

--- a/cvat/apps/engine/static/engine/js/shapes.js
+++ b/cvat/apps/engine/static/engine/js/shapes.js
@@ -1652,15 +1652,19 @@ class RaysController extends PolyShapeController {
 
     stretchUpdateLineCoordinates(lineElement, isBigRotation, initialRatio, initialPosition, lineElements) {
         const {
-            projectOntoLine,
-            getLineByTwoPoints,
+            pointsDistance,
         } = window.graphicPrimitives;
-        const line = getLineByTwoPoints(initialPosition[0], initialPosition[1]);
         let [a, b] = this.extractPoints(lineElement);
-        a = projectOntoLine(a, line);
-        b = projectOntoLine(b, line);
-        this.setPoints(lineElement, initialPosition);
         const newVanishingPoint = this.getPointFromRatio(a, b, initialRatio);
+        const ratio = pointsDistance(...initialPosition) / pointsDistance(a, b);
+        if (!Number.isFinite(ratio)) {
+            [a, b] = initialPosition;
+        } else  if (isBigRotation) {
+            b = this.getPointFromRatio(a, b, ratio);
+        } else {
+            a = this.getPointFromRatio(b, a, ratio);
+        }
+        this.setPoints(lineElement, [a, b]);
         lineElements.forEach((element) => {
             if (element === lineElement) {
                 return;

--- a/cvat/apps/engine/static/engine/js/shapes.js
+++ b/cvat/apps/engine/static/engine/js/shapes.js
@@ -1689,7 +1689,8 @@ class RaysController extends PolyShapeController {
                     return;
                 }
                 const points = this.extractPoints(element);
-                const newPoints = this.rotate(points, points[0], newVanishingPoint);
+                const rotPoint = isBigRotation ? points[0] : points[1];
+                const newPoints = this.rotate(points, rotPoint, newVanishingPoint);
                 this.setPoints(element, newPoints);
             });
             this._model._vanishingPoint = newVanishingPoint;


### PR DESCRIPTION
Do not include vanishing point into the shape on ctrl+c ctrl+v (which is inconvenient for annotators on big zoom).
Fix line removal not working.
Make shift+dragging move close/distant to the vanishing point edges depending on the clicked edge rather than always move close edges (to make it more unified with other features).
Make ctrl+dragging to change the angle of vanishing point (previously only the distance to the vanishing point could be changed this way)