### PR TITLE
Create separate bundle for attribute-editor

### DIFF
--- a/cvat-ui/src/attribute-editor-index.tsx
+++ b/cvat-ui/src/attribute-editor-index.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+import ReactDOM from 'react-dom';
+import 'antd/dist/antd.less';
+
+import AttributeEditor from "./components/attribute-editor/attribute-editor";
+
+
+const editorRoot = document.getElementById('range-attribute-editor-root');
+if (editorRoot) {
+    document.addEventListener('annotation-page-content-loaded', (event) => {
+        const {start, stop, labelsInfo, shapeCollection} = event.detail;
+        ReactDOM.render(
+            <AttributeEditor
+                start={start}
+                stop={stop}
+                labelsInfo={labelsInfo}
+                shapeCollection={shapeCollection}
+            />,
+            editorRoot
+        );
+    });
+}

--- a/cvat-ui/src/index.tsx
+++ b/cvat-ui/src/index.tsx
@@ -8,7 +8,6 @@ import { connect, Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom';
 
 import CVATApplication from './components/cvat-app';
-import AttributeEditor from "./components/attribute-editor/attribute-editor";
 
 import createRootReducer from './reducers/root-reducer';
 import createCVATStore, { getCVATStore } from './cvat-store';
@@ -103,32 +102,13 @@ const ReduxAppWrapper = connect(
     mapDispatchToProps,
 )(CVATApplication);
 
-const root = document.getElementById('root');
-if (root) {
-    ReactDOM.render(
-        (
-            <Provider store={cvatStore}>
-                <BrowserRouter>
-                    <ReduxAppWrapper />
-                </BrowserRouter>
-            </Provider>
-        ),
-        root,
-    );
-}
-
-const editorRoot = document.getElementById('range-attribute-editor-root');
-if (editorRoot) {
-    document.addEventListener('annotation-page-content-loaded', (event) => {
-        const {start, stop, labelsInfo, shapeCollection } = event.detail;
-        ReactDOM.render(
-            <AttributeEditor
-                start={start}
-                stop={stop}
-                labelsInfo={labelsInfo}
-                shapeCollection={shapeCollection}
-            />,
-            editorRoot
-        );
-    });
-}
+ReactDOM.render(
+    (
+        <Provider store={cvatStore}>
+            <BrowserRouter>
+                <ReduxAppWrapper />
+            </BrowserRouter>
+        </Provider>
+    ),
+    document.getElementById('root'),
+);

--- a/cvat-ui/webpack.config.js
+++ b/cvat-ui/webpack.config.js
@@ -13,10 +13,13 @@ module.exports = {
     target: 'web',
     mode: 'production',
     devtool: 'source-map',
-    entry: './src/index.tsx',
+    entry: {
+        "cvat-ui": './src/index.tsx',
+        "attribute-editor": './src/attribute-editor-index.tsx',
+    },
     output: {
         path: path.resolve(__dirname, 'dist'),
-        filename: 'cvat-ui.min.js',
+        filename: '[name].min.js',
     },
     devServer: {
         contentBase: path.join(__dirname, 'dist'),

--- a/cvat/apps/engine/templates/engine/annotation.html
+++ b/cvat/apps/engine/templates/engine/annotation.html
@@ -486,5 +486,5 @@
 {% endblock %}
 
 {% block footer %}
-    <script src="/cvat-ui.min.js" type="text/javascript"></script>
+    <script src="/attribute-editor.min.js" type="text/javascript"></script>
 {% endblock %}


### PR DESCRIPTION
`cvat-ui.min.js` execution on annotation page leads to some functions on `window` object get overridden which leads to bugs. Fix it by moving attribute editor to its own bundle and not executing  `cvat-ui.min.js` on annotation page.