### PR TITLE
Fix false positives in vls checks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,7 +51,7 @@ RUN apt-get update && \
     else \
         echo export "GIT_SSH_COMMAND=\"ssh -o StrictHostKeyChecking=no -o ConnectTimeout=30 -o ProxyCommand='nc -X 5 -x ${socks_proxy} %h %p'\"" >> ${HOME}/.bashrc; \
     fi && \
-    python3 -m pip install --no-cache-dir -U pip==20.0.1 setuptools && \
+    python3 -m pip install --no-cache-dir -U pip==20.0.1 setuptools==50.3.2 && \
     ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \
     add-apt-repository --remove ppa:mc3man/gstffmpeg-keep -y && \

--- a/cvat/apps/engine/ddln/tasks/vls_lines/models.py
+++ b/cvat/apps/engine/ddln/tasks/vls_lines/models.py
@@ -104,10 +104,11 @@ class Runway:
         original = [self.end_line, self.designator_line, self.start_line]
         if any(line is None for line in original):
             return
+        reference_line = self.center_line or self.left_line or self.right_line
         distant_point = self.lon_vanishing_point
-        if not distant_point:
+        if not (distant_point and reference_line):
             return
-        final = sorted(original, key=lambda line: distant_point.distance_to(line))
+        final = sorted(original, key=lambda line: distant_point.distance_to(reference_line.intersect(line)))
         if final != original:
             reporter.report_lat_disorder()
 

--- a/cvat/apps/engine/ddln/tasks/vls_lines/validation.py
+++ b/cvat/apps/engine/ddln/tasks/vls_lines/validation.py
@@ -103,10 +103,10 @@ class VlsLinesValidationReporter(BaseValidationReporter):
         self._report("Runway id has changed from {} to {}".format(previous, current), self.severity.WARNING)
 
     def report_lat_disorder(self):
-        self._report("Lateral rays are mixed up")
+        self._report("Horizontal rays are mixed up")
 
     def report_lon_disorder(self):
-        self._report("Longitudinal rays are mixed up")
+        self._report("Vertical rays are mixed up")
 
     def report_wrong_values_amount(self, expected, actual):
         self._report("Wrong values amount. Expected: {}, actual: {}".format(expected, actual))

--- a/cvat/apps/engine/static/engine/js/shapeCreator.js
+++ b/cvat/apps/engine/static/engine/js/shapeCreator.js
@@ -872,6 +872,9 @@ class ShapeCreatorView {
 
     _rescaleDrawPoints() {
         const scale = this._scale;
+        $(".svg_select_points").each(function () {
+            this.instance.radius(2.5 / scale).attr("stroke-width", 1 / scale);
+        });
         $(".svg_draw_point").each(function () {
             this.instance.radius(2.5 / scale).attr("stroke-width", 1 / scale);
         });

--- a/datumaro/requirements.txt
+++ b/datumaro/requirements.txt
@@ -8,3 +8,4 @@ pycocotools>=2.0.0
 PyYAML>=5.1.1
 scikit-image>=0.15.0
 tensorboardX>=1.8
+setuptools==50.3.2


### PR DESCRIPTION
Update 'runway id changed' check to work properly when there are multiple runways in the sequence.
Fix 'lateral rays order' check to work properly in edge cases.
Fix points not scaling properly.
Freeze `setuptools` version to successfully build docker image.